### PR TITLE
HTTPサーバーを疎結合な構成に変更

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,16 @@
+package config
+
+import "github.com/caarlos0/env/v6"
+
+type Config struct {
+	Env  string `env:"TODO_ENV" envDefault:"dev"`
+	Port int    `env:"PORT" envDefault:"80"`
+}
+
+func New() (*Config, error) {
+	cfg := &Config{}
+	if err := env.Parse(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	wantPort := 3333
+	t.Setenv("PORT", fmt.Sprint(wantPort))
+
+	got, err := New()
+	if err != nil {
+		t.Fatalf("cannot create config: %v", err)
+	}
+	if got.Port != wantPort {
+		t.Errorf("want %d, but got %d", wantPort, got.Port)
+	}
+	wantEnv := "dev"
+	if got.Env != wantEnv {
+		t.Errorf("want %s, but got %s", wantEnv, got.Env)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@ services:
     build:
       args:
         - target=dev
+    environment:
+      TODO_ENV: dev
+      PORT: 8080
     volumes:
       - .:/app
     ports:
-        - "18000:80"
+        - "18000:8080"

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/y-magavel/go-todo-api
 
 go 1.18
 
-require golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde // indirect
+require (
+	github.com/caarlos0/env/v6 v6.10.0 // indirect
+	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/caarlos0/env/v6 v6.10.0 h1:lA7sxiGArZ2KkiqpOQNf8ERBRWI+v8MWIH+eGjSN22I=
+github.com/caarlos0/env/v6 v6.10.0/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/main.go
+++ b/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/y-magavel/go-todo-api/config"
 	"log"
 	"net"
 	"os"
+
+	"github.com/y-magavel/go-todo-api/config"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 )
 
 func main() {
@@ -19,6 +22,8 @@ func main() {
 }
 
 func run(ctx context.Context) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	cfg, err := config.New()
 	if err != nil {
 		return err
@@ -32,6 +37,8 @@ func run(ctx context.Context) error {
 
 	s := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// コマンドラインで実験するため
+			time.Sleep(5 * time.Second)
 			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
 		}),
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/y-magavel/go-todo-api/config"
 	"golang.org/x/sync/errgroup"
 	"log"
 	"net"
@@ -11,25 +12,24 @@ import (
 )
 
 func main() {
-
-	// コマンドライン引数からポート番号を取得する
-	if len(os.Args) != 2 {
-		log.Printf("need port number\n")
-		os.Exit(1)
-	}
-	p := os.Args[1]
-	l, err := net.Listen("tcp", ":"+p)
-	if err != nil {
-		log.Fatalf("failed to listen port %s: %v", p, err)
-	}
-
-	if err := run(context.Background(), l); err != nil {
+	if err := run(context.Background()); err != nil {
 		fmt.Printf("failed to terminate server: %v", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, l net.Listener) error {
+func run(ctx context.Context) error {
+	cfg, err := config.New()
+	if err != nil {
+		return err
+	}
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
+	if err != nil {
+		log.Fatalf("failed to listen port %d: %v", cfg.Port, err)
+	}
+	url := fmt.Sprintf("http://%s", l.Addr().String())
+	log.Printf("start with %v", url)
+
 	s := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])

--- a/main.go
+++ b/main.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/y-magavel/go-todo-api/config"
-	"golang.org/x/sync/errgroup"
 	"log"
 	"net"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
 )
 
 func main() {
@@ -22,44 +17,21 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer stop()
 	cfg, err := config.New()
 	if err != nil {
 		return err
 	}
+
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
 	if err != nil {
 		log.Fatalf("failed to listen port %d: %v", cfg.Port, err)
 	}
+
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with %v", url)
 
-	s := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// コマンドラインで実験するため
-			time.Sleep(5 * time.Second)
-			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
-		}),
-	}
+	mux := NewMux()
+	s := NewServer(l, mux)
 
-	// 別ゴルーチンでHTTPサーバーを起動する
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		if err := s.Serve(l); err != nil && err != http.ErrServerClosed {
-			log.Printf("failed to close: %v", err)
-			return err
-		}
-		return nil
-	})
-
-	// チャネルからの通知（終了通知）を待機する
-	<-ctx.Done()
-	if err := s.Shutdown(context.Background()); err != nil {
-		log.Printf("failed to shutdown: %+v", err)
-		return err
-	}
-
-	// Goメソッドで起動した別ゴルーチンの終了を待つ
-	return eg.Wait()
+	return s.Run(ctx)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestRun(t *testing.T) {
+	t.Skip("リファクタリング中")
+
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
@@ -19,7 +21,7 @@ func TestRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return run(ctx, l)
+		return run(ctx)
 	})
 
 	in := "message"

--- a/mux.go
+++ b/mux.go
@@ -1,0 +1,13 @@
+package main
+
+import "net/http"
+
+func NewMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// 静的解析のエラーを回避するために明示的に戻り値を捨てている
+		_, _ = w.Write([]byte(`{"status": "ok"}`))
+	})
+	return mux
+}

--- a/mux_test.go
+++ b/mux_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewMux(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	sut := NewMux()
+	sut.ServeHTTP(w, r)
+	resp := w.Result()
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusOK {
+		t.Error("want status code 200, but got", resp.StatusCode)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	want := `{"status": "ok"}`
+	if string(got) != want {
+		t.Errorf("want %q, but got %q", want, got)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"context"
-	"golang.org/x/sync/errgroup"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type Server struct {

--- a/server.go
+++ b/server.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"golang.org/x/sync/errgroup"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type Server struct {
+	srv *http.Server
+	l   net.Listener
+}
+
+func NewServer(l net.Listener, mux http.Handler) *Server {
+	return &Server{
+		srv: &http.Server{Handler: mux},
+		l:   l,
+	}
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// 別ゴルーチンでHTTPサーバーを起動する
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		if err := s.srv.Serve(s.l); err != nil && err != http.ErrServerClosed {
+			log.Printf("failed to close: %v", err)
+			return err
+		}
+		return nil
+	})
+
+	// チャネルからの通知（終了通知）を待機する
+	<-ctx.Done()
+	if err := s.srv.Shutdown(context.Background()); err != nil {
+		log.Printf("failed to shutdown: %+v", err)
+	}
+
+	// グレースフルシャットダウンの終了を待つ
+	return eg.Wait()
+}

--- a/server_test.go
+++ b/server_test.go
@@ -10,9 +10,7 @@ import (
 	"testing"
 )
 
-func TestRun(t *testing.T) {
-	t.Skip("リファクタリング中")
-
+func TestServer_Run(t *testing.T) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
@@ -20,8 +18,13 @@ func TestRun(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
+	mux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+	})
+
 	eg.Go(func() error {
-		return run(ctx)
+		s := NewServer(l, mux)
+		return s.Run(ctx)
 	})
 
 	in := "message"


### PR DESCRIPTION
### 概要
HTTPサーバーを疎結合な構成に変更した

### 詳細
- 環境変数から設定をロードするよう実装
- グレースフルシャットダウンの実現
- Server型とNewMux関数の実装

### 備考
CHAPTER16 pp.151-164